### PR TITLE
M-109: Fixed room update failing when adding additional question

### DIFF
--- a/app/Http/Controllers/EditRoomController.php
+++ b/app/Http/Controllers/EditRoomController.php
@@ -55,10 +55,13 @@ class EditRoomController extends Controller
 			collect($question["answers"])->each(function ($answer) use (
 				$updatedQuestion
 			) {
-				$updatedQuestion
-					->answers()
-					->where("id", $answer["id"])
-					->update(["answer" => $answer["value"]]);
+				$updatedQuestion->answers()->updateOrCreate(
+					["id" => $answer["id"]],
+					[
+						"answer" => $answer["value"],
+						"is_correct" => $answer["isCorrect"],
+					]
+				);
 			});
 		});
 

--- a/resources/js/components/HasMany/HasMany.tsx
+++ b/resources/js/components/HasMany/HasMany.tsx
@@ -53,18 +53,22 @@ export const HasMany: React.VFC<{
 									value: "",
 									answers: [
 										{
+											id: null,
 											value: "",
 											isCorrect: true,
 										},
 										{
+											id: null,
 											value: "",
 											isCorrect: false,
 										},
 										{
+											id: null,
 											value: "",
 											isCorrect: false,
 										},
 										{
+											id: null,
 											value: "",
 											isCorrect: false,
 										},


### PR DESCRIPTION
https://trello.com/c/pouiEFb6/109-bug-updating-room-fails-if-you-add-question

I did it this way because question updation was made in similar fashion. If new question and now answer is created its id is always provided as `null`. Not sure if this is the correct way to go about it.